### PR TITLE
Fix double-escaping on repeated metadata updates

### DIFF
--- a/src/tools/calendar.py
+++ b/src/tools/calendar.py
@@ -340,12 +340,18 @@ class GoogleCalendarTools:
             if "description" in params:
                 event["description"] = params["description"]
 
-            # Validate and append metadata to description if provided
+            # Validate and replace metadata in description if provided
             if "metadata" in params and params["metadata"]:
                 validated_metadata = self._validate_metadata(params["metadata"])
                 # Get existing description or empty string
                 description = event.get("description", "")
-                # Append validated metadata
+
+                # Remove existing metadata section if present to prevent double-escaping
+                metadata_marker = "\n\n---\n📋 Context:\n"
+                if metadata_marker in description:
+                    description = description.split(metadata_marker)[0]
+
+                # Append new validated metadata
                 description += self._format_metadata(validated_metadata)
                 event["description"] = description
 


### PR DESCRIPTION
## Summary

Fixes #25 - Prevents double-escaping when updating event metadata multiple times.

## Problem

When updating an event that already has metadata with escaped HTML, calling `_validate_metadata()` again would double-escape the content.

**Example Scenario:**
1. First update: User provides "Q&A" → Stored as "Q&amp;A" in description
2. Second update: User provides "Q&A" again → Re-escaped to "Q&amp;amp;A" (double-escaped)
3. Third update: "Q&amp;amp;amp;A" (triple-escaped)

This degrades data quality over time.

## Solution

Strip existing metadata section before appending new validated metadata (src/tools/calendar.py:349-356):

```python
# Remove existing metadata section if present to prevent double-escaping
metadata_marker = "\n\n---\n📋 Context:\n"
if metadata_marker in description:
    description = description.split(metadata_marker)[0]

# Append new validated metadata
description += self._format_metadata(validated_metadata)
```

**Benefits:**
- Metadata is replaced, not appended
- No double-escaping on repeated updates
- User notes preserved (before metadata marker)
- Old metadata cleanly removed

## Testing

Added 2 new integration tests:

1. **test_update_event_repeated_updates_no_double_escaping**
   - Updates event twice with "Q&A Session"
   - Verifies only one instance of "Q&amp;A" (not "Q&amp;amp;A")
   - Confirms original description preserved

2. **test_update_event_replaces_old_metadata**
   - Updates event with completely different metadata
   - Verifies old metadata removed ("Old Project", "2025-09-01")
   - Verifies new metadata present ("New Project", "2025-09-28")
   - Confirms user notes preserved

**Test Results:** ✅ All 154 tests passing

## Files Changed
- `src/tools/calendar.py` - Strip metadata section before appending (lines 349-356)
- `tests/test_metadata_validation.py` - Add 2 integration tests (lines 432-542)

## Checklist
- [x] Metadata section replaced, not appended
- [x] Test for repeated updates without double-escaping
- [x] Test for metadata replacement
- [x] User notes preserved
- [x] All 154 tests pass
- [x] Flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)