### PR TITLE
Handle empty metadata edge case gracefully

### DIFF
--- a/src/tools/calendar.py
+++ b/src/tools/calendar.py
@@ -182,8 +182,17 @@ class GoogleCalendarTools:
                      chat_title, chat_url
 
         Returns:
-            Formatted metadata string to append to description
+            Formatted metadata string to append to description, or empty string if no content
         """
+        # Check if any metadata fields have actual values
+        has_content = any(
+            metadata.get(key)
+            for key in ["created_date", "project_name", "chat_title", "chat_url"]
+        )
+
+        if not has_content:
+            return ""
+
         metadata_section = "\n\n---\n📋 Context:\n"
 
         if metadata.get("created_date"):

--- a/tests/test_metadata_validation.py
+++ b/tests/test_metadata_validation.py
@@ -295,6 +295,66 @@ class TestMetadataValidation:
         assert "unknown_field" not in result
 
 
+class TestFormatMetadata:
+    """Test cases for _format_metadata method."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_auth_manager = Mock()
+        self.calendar_tools = GoogleCalendarTools(self.mock_auth_manager)
+
+    def test_format_empty_metadata_returns_empty_string(self):
+        """Test that empty metadata dict returns empty string."""
+        result = self.calendar_tools._format_metadata({})
+        assert result == ""
+
+    def test_format_metadata_all_none_values_returns_empty_string(self):
+        """Test that metadata with all None values returns empty string."""
+        metadata = {
+            "created_date": None,
+            "project_name": None,
+            "chat_title": None,
+            "chat_url": None,
+        }
+        result = self.calendar_tools._format_metadata(metadata)
+        assert result == ""
+
+    def test_format_metadata_all_empty_strings_returns_empty_string(self):
+        """Test that metadata with all empty strings returns empty string."""
+        metadata = {
+            "created_date": "",
+            "project_name": "",
+            "chat_title": "",
+            "chat_url": "",
+        }
+        result = self.calendar_tools._format_metadata(metadata)
+        assert result == ""
+
+    def test_format_metadata_with_one_field_formats_correctly(self):
+        """Test that metadata with one field formats correctly."""
+        metadata = {"chat_title": "Test Chat"}
+        result = self.calendar_tools._format_metadata(metadata)
+        assert "\n\n---\n📋 Context:\n" in result
+        assert "Chat: Test Chat" in result
+        assert "Created:" not in result
+        assert "Project:" not in result
+
+    def test_format_metadata_with_all_fields_formats_correctly(self):
+        """Test that metadata with all fields formats correctly."""
+        metadata = {
+            "created_date": "2025-09-28",
+            "project_name": "Test Project",
+            "chat_title": "Test Chat",
+            "chat_url": "https://claude.ai/chat/test123",
+        }
+        result = self.calendar_tools._format_metadata(metadata)
+        assert "\n\n---\n📋 Context:\n" in result
+        assert "Created: 2025-09-28" in result
+        assert "Project: Test Project" in result
+        assert "Chat: Test Chat" in result
+        assert "URL: https://claude.ai/chat/test123" in result
+
+
 class TestUpdateEventValidation:
     """Test cases for update_event metadata validation."""
 


### PR DESCRIPTION
## Summary

Fixes #20 - Prevents empty metadata separator from appearing when no metadata content is provided.

## Problem

When an empty metadata object `{}` or metadata with only None/empty values is passed, the current implementation creates an unnecessary separator:

```
Event Description: Meeting notes here

---
📋 Context:

```

This adds visual clutter without providing any actual metadata information.

## Solution

Check if metadata has any actual content before formatting the section (src/tools/calendar.py:187-194):

```python
# Check if any metadata fields have actual values
has_content = any(
    metadata.get(key)
    for key in ["created_date", "project_name", "chat_title", "chat_url"]
)

if not has_content:
    return ""
```

**Behavior:**
- ✅ Empty dict `{}` → Returns empty string (no separator)
- ✅ All None values → Returns empty string (no separator)
- ✅ All empty strings → Returns empty string (no separator)
- ✅ One valid field → Formats separator + that field
- ✅ Multiple valid fields → Formats separator + all fields

## Benefits
- ✅ Cleaner event descriptions (no empty separators)
- ✅ Better user experience
- ✅ Metadata section only appears when there's actual content

## Testing

Added 5 comprehensive tests in new `TestFormatMetadata` class:

1. **test_format_empty_metadata_returns_empty_string**
   - Verifies `{}` returns `""`

2. **test_format_metadata_all_none_values_returns_empty_string**
   - Verifies all None values returns `""`

3. **test_format_metadata_all_empty_strings_returns_empty_string**
   - Verifies all empty strings returns `""`

4. **test_format_metadata_with_one_field_formats_correctly**
   - Verifies partial metadata formats correctly

5. **test_format_metadata_with_all_fields_formats_correctly**
   - Verifies full metadata formats correctly

**Test Results:** ✅ All 164 tests passing (added 5 new)

## Files Changed
- `src/tools/calendar.py` - Add content check to `_format_metadata()` (lines 187-194)
- `tests/test_metadata_validation.py` - Add `TestFormatMetadata` class with 5 tests

## Checklist
- [x] Check if metadata has content before formatting
- [x] Return empty string when no content
- [x] Test empty dict edge case
- [x] Test all None values edge case
- [x] Test all empty strings edge case
- [x] Test partial metadata still formats
- [x] All 164 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)