### PR TITLE
Extract magic numbers to named constants

### DIFF
--- a/src/tools/calendar.py
+++ b/src/tools/calendar.py
@@ -20,6 +20,10 @@ logger = logging.getLogger(__name__)
 # Default timezone constant
 DEFAULT_TIMEZONE = "America/Toronto"
 
+# Metadata field length limits
+MAX_CHAT_TITLE_LENGTH = 200
+MAX_PROJECT_NAME_LENGTH = 100
+
 
 class GoogleCalendarTools:
     """Handles Google Calendar operations."""
@@ -156,7 +160,7 @@ class GoogleCalendarTools:
 
         if "chat_title" in metadata:
             validated["chat_title"] = self._validate_text_field(
-                metadata["chat_title"], "chat_title", 200
+                metadata["chat_title"], "chat_title", MAX_CHAT_TITLE_LENGTH
             )
 
         if "chat_url" in metadata:
@@ -164,7 +168,7 @@ class GoogleCalendarTools:
 
         if "project_name" in metadata:
             validated["project_name"] = self._validate_text_field(
-                metadata["project_name"], "project_name", 100
+                metadata["project_name"], "project_name", MAX_PROJECT_NAME_LENGTH
             )
 
         if "created_date" in metadata:


### PR DESCRIPTION
## Summary

Fixes #27 - Extracts magic numbers (200, 100) to named constants for better code maintainability.

## Problem

Magic numbers appeared directly in validation calls without context:

```python
self._validate_text_field(metadata["chat_title"], "chat_title", 200)
self._validate_text_field(metadata["project_name"], "project_name", 100)
```

**Issues:**
- ❌ Unclear what 200 and 100 represent
- ❌ No single source of truth if limits need to change
- ❌ Harder to maintain across codebase

## Solution

Extract to self-documenting constants at module level (src/tools/calendar.py:23-25):

```python
# Metadata field length limits
MAX_CHAT_TITLE_LENGTH = 200
MAX_PROJECT_NAME_LENGTH = 100
```

Use constants in validation calls (lines 163, 171):

```python
self._validate_text_field(
    metadata["chat_title"], "chat_title", MAX_CHAT_TITLE_LENGTH
)
self._validate_text_field(
    metadata["project_name"], "project_name", MAX_PROJECT_NAME_LENGTH
)
```

## Benefits

- ✅ **Self-documenting**: Constants explain what values control
- ✅ **Single source of truth**: Change limit in one place
- ✅ **Easier maintenance**: Clear where to update limits
- ✅ **Consistent pattern**: Follows existing `DEFAULT_TIMEZONE` constant
- ✅ **No behavior change**: Pure refactoring

## Files Changed

- `src/tools/calendar.py` - Add constants (lines 23-25), use in validation (lines 163, 171)

## Testing

- ✅ All 164 tests passing
- ✅ No test changes needed (behavior unchanged)
- ✅ Validation logic identical

## Checklist

- [x] Extract MAX_CHAT_TITLE_LENGTH = 200
- [x] Extract MAX_PROJECT_NAME_LENGTH = 100
- [x] Replace magic numbers with constants
- [x] All 164 tests pass
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)