### PR TITLE
Add edge case tests for date validation

### DIFF
--- a/tests/test_metadata_validation.py
+++ b/tests/test_metadata_validation.py
@@ -247,6 +247,34 @@ class TestMetadataValidation:
         result = self.calendar_tools._validate_metadata({"created_date": "2024-02-29"})
         assert result["created_date"] == "2024-02-29"
 
+    def test_validate_created_date_day_zero_raises_error(self):
+        """Test day 0 raises ValueError."""
+        with pytest.raises(
+            ValueError, match="created_date must be in ISO format \\(YYYY-MM-DD\\)"
+        ):
+            self.calendar_tools._validate_metadata({"created_date": "2025-01-00"})
+
+    def test_validate_created_date_month_zero_raises_error(self):
+        """Test month 0 raises ValueError."""
+        with pytest.raises(
+            ValueError, match="created_date must be in ISO format \\(YYYY-MM-DD\\)"
+        ):
+            self.calendar_tools._validate_metadata({"created_date": "2025-00-15"})
+
+    def test_validate_created_date_negative_day_raises_error(self):
+        """Test negative day raises ValueError."""
+        with pytest.raises(
+            ValueError, match="created_date must be in ISO format \\(YYYY-MM-DD\\)"
+        ):
+            self.calendar_tools._validate_metadata({"created_date": "2025-01--05"})
+
+    def test_validate_created_date_negative_month_raises_error(self):
+        """Test negative month raises ValueError."""
+        with pytest.raises(
+            ValueError, match="created_date must be in ISO format \\(YYYY-MM-DD\\)"
+        ):
+            self.calendar_tools._validate_metadata({"created_date": "2025--01-15"})
+
     def test_validate_created_date_empty_string_raises_error(self):
         """Test empty created_date raises ValueError."""
         with pytest.raises(ValueError, match="created_date cannot be empty"):


### PR DESCRIPTION
## Summary

Fixes #31 - Adds comprehensive edge case tests to document `strptime()` behavior with invalid date inputs.

## Problem

Date validation tests covered common invalid cases (Feb 30, month 13, April 31, leap years) but didn't test numeric edge cases:
- Day 0
- Month 0
- Negative day values
- Negative month values

Behavior with these inputs was undocumented.

## Solution

Add 4 new tests to verify `strptime()` correctly rejects these edge cases:

### 1. **test_validate_created_date_day_zero_raises_error**
```python
# Verifies "2025-01-00" is rejected
# Day must be >= 1
```

### 2. **test_validate_created_date_month_zero_raises_error**
```python
# Verifies "2025-00-15" is rejected
# Month must be >= 1 (1-12 range)
```

### 3. **test_validate_created_date_negative_day_raises_error**
```python
# Verifies "2025-01--05" is rejected
# No negative day values allowed
```

### 4. **test_validate_created_date_negative_month_raises_error**
```python
# Verifies "2025--01-15" is rejected
# No negative month values allowed
```

## Testing Results

All edge cases **already correctly rejected** by `strptime()`:

```
day 0 (2025-01-00): REJECTED - does not match format '%Y-%m-%d'
month 0 (2025-00-15): REJECTED - does not match format '%Y-%m-%d'
negative day (2025-01--05): REJECTED - does not match format '%Y-%m-%d'
negative month (2025--01-15): REJECTED - does not match format '%Y-%m-%d'
```

## Benefits

- ✅ **Documents behavior**: Explicit tests show edge cases are handled
- ✅ **Prevents regression**: Tests catch if validation changes unexpectedly
- ✅ **Completes coverage**: Fills gaps in date validation test suite
- ✅ **No code changes**: Validation already correct, just documenting it

## Files Changed

- `tests/test_metadata_validation.py` - Add 4 edge case tests (lines 250-276)

## Test Results

- ✅ All 168 tests passing (added 4 new)
- ✅ No functional changes
- ✅ Pure test additions

## Checklist

- [x] Test day 0 rejection
- [x] Test month 0 rejection
- [x] Test negative day rejection
- [x] Test negative month rejection
- [x] Verify strptime behavior
- [x] All 168 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)