### PR TITLE
refactor: Migrate from flake8/isort to ruff for faster linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,19 +27,15 @@ jobs:
 
       - name: Install linting tools
         run: |
-          pip install flake8 mypy black isort types-aiofiles
+          pip install ruff mypy black types-aiofiles
 
       - name: Check code formatting (Black)
         run: |
           black --check src/ tests/ || (echo "❌ Code formatting issues found. Run 'black src/ tests/' to fix." && exit 1)
 
-      - name: Check import sorting (isort)
+      - name: Lint and check imports (Ruff)
         run: |
-          isort --profile black --check-only src/ tests/ || (echo "❌ Import sorting issues found. Run 'isort --profile black src/ tests/' to fix." && exit 1)
-
-      - name: Lint code (Flake8)
-        run: |
-          flake8 src/ tests/ --max-line-length=100 --extend-ignore=E203,W503
+          ruff check src/ tests/ || (echo "❌ Linting or import issues found. Run 'ruff check --fix src/ tests/' to fix." && exit 1)
 
       - name: Type checking (Mypy)
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,6 @@ pytest-cov>=4.1.0
 
 # Development
 black>=23.3.0
-flake8>=6.0.0
+ruff>=0.1.0
 mypy>=1.3.0
 types-aiofiles>=23.1.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,27 @@
+# Ruff configuration - replaces flake8 and isort
+# https://docs.astral.sh/ruff/
+
+# General configuration
+line-length = 100
+
+# Linting rules
+[lint]
+# Enable rules
+select = [
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
+    "I",   # isort (import sorting)
+    "W",   # pycodestyle warnings
+]
+
+# Ignore specific rules to match previous flake8 config
+ignore = [
+    "E203",  # Whitespace before ':' (conflicts with Black)
+]
+
+# Import sorting configuration (isort replacement)
+# Black-compatible settings
+[lint.isort]
+force-single-line = false
+force-wrap-aliases = false
+split-on-trailing-comma = true


### PR DESCRIPTION
## Summary
Migrates from flake8 and isort to ruff for faster, unified linting and import sorting.

## Changes
- ✅ Added `ruff.toml` configuration matching previous rules
- ✅ Updated `requirements.txt` (removed flake8, added ruff)
- ✅ Updated CI workflow to use single `ruff check` command
- ✅ All checks pass locally

## Configuration
- **Line length**: 100 (maintained)
- **Rules**: E (pycodestyle), F (pyflakes), I (isort), W (warnings)
- **Ignored**: E203 (conflicts with Black)
- **Import sorting**: Black-compatible settings

## Benefits
- ⚡ **10-100x faster** than flake8 (Rust-based)
- 🔧 **Single tool** for linting + import sorting
- 📦 **Simpler** configuration and maintenance
- ⏱️ **Faster CI/CD** pipeline execution

## Testing
```bash
ruff check src/ tests/
# All checks passed!
```

Fixes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)