### PR TITLE
fix: Configure SonarCloud to exclude non-source files from coverage

### DIFF
--- a/scripts/auth_calendar_only.py
+++ b/scripts/auth_calendar_only.py
@@ -2,89 +2,90 @@
 """Generate OAuth URL for Calendar, Docs, and Drive only."""
 
 import os
-import sys
 import pickle
+import sys
 from pathlib import Path
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 # Only the scopes you want
 SCOPES = [
-    'https://www.googleapis.com/auth/calendar',
-    'https://www.googleapis.com/auth/documents', 
-    'https://www.googleapis.com/auth/drive.file',
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive.file",
 ]
+
 
 def generate_url():
     """Generate fresh OAuth URL for limited scopes."""
-    credentials_path = 'config/credentials.json'
-    
+    credentials_path = "config/credentials.json"
+
     if not os.path.exists(credentials_path):
         print(f"❌ Credentials file not found: {credentials_path}")
         return None
-    
+
     try:
         print("🔄 Generating fresh OAuth URL...")
         print("📋 Requested scopes:")
         for i, scope in enumerate(SCOPES, 1):
             print(f"  {i}. {scope}")
-        
+
         # Create flow
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
-        flow.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
-        
+        flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+
         # Get authorization URL
         auth_url, _ = flow.authorization_url(
-            access_type='offline',
-            prompt='consent',
-            include_granted_scopes='true'
+            access_type="offline", prompt="consent", include_granted_scopes="true"
         )
-        
-        print(f"\n🌐 Visit this URL in your browser:")
+
+        print("\n🌐 Visit this URL in your browser:")
         print(f"\n{auth_url}\n")
-        
+
         return flow
-        
+
     except Exception as e:
         print(f"❌ Failed to generate URL: {e}")
         return None
 
+
 def complete_auth(flow, auth_code):
     """Complete authentication with authorization code."""
-    token_path = Path('config/token.pickle')
-    
+    token_path = Path("config/token.pickle")
+
     try:
         print("🔄 Exchanging authorization code for tokens...")
-        
+
         # Exchange code for tokens
         flow.fetch_token(code=auth_code)
         creds = flow.credentials
-        
+
         # Save credentials
         token_path.parent.mkdir(exist_ok=True)
-        with open(token_path, 'wb') as token:
+        with open(token_path, "wb") as token:
             pickle.dump(creds, token)
-            
-        print(f"✅ Authentication successful!")
+
+        print("✅ Authentication successful!")
         print(f"💾 Token saved to: {token_path}")
         print(f"🔑 Token valid: {creds.valid}")
-        
-        if hasattr(creds, 'refresh_token') and creds.refresh_token:
+
+        if hasattr(creds, "refresh_token") and creds.refresh_token:
             print("🔄 Refresh token available - automatic renewal enabled")
-        
+
         print("\n✅ Available services:")
-        print("  📅 Google Calendar")  
+        print("  📅 Google Calendar")
         print("  📄 Google Docs")
         print("  📁 Google Drive")
-        
+
         return True
-        
+
     except Exception as e:
         print(f"❌ Token exchange failed: {e}")
         return False
+
 
 def main():
     """Main authentication flow."""
@@ -94,7 +95,7 @@ def main():
         if flow:
             print("📋 Steps:")
             print("1. Copy the URL above")
-            print("2. Open it in your browser") 
+            print("2. Open it in your browser")
             print("3. Grant permissions")
             print("4. Copy the authorization code")
             print("5. Run: python auth_calendar_only.py <code>")
@@ -110,8 +111,9 @@ def main():
         print("  python auth_calendar_only.py              # Generate OAuth URL")
         print("  python auth_calendar_only.py <code>       # Complete with auth code")
         return 1
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/complete_auth.py
+++ b/scripts/complete_auth.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
 """Complete Google OAuth authentication with authorization code."""
 
-import sys
 import os
 import pickle
+import sys
 from pathlib import Path
-sys.path.append('src')
+
+sys.path.append("src")
 
 from google_auth_oauthlib.flow import InstalledAppFlow
+
 from auth.google_auth import GoogleAuthManager
+
 
 def complete_auth(auth_code):
     """Complete authentication with authorization code."""
-    credentials_path = 'config/credentials.json'
-    token_path = Path('config/token.pickle')
+    credentials_path = "config/credentials.json"
+    token_path = Path("config/token.pickle")
 
     if not os.path.exists(credentials_path):
         print(f"❌ Credentials file not found: {credentials_path}")
@@ -24,7 +27,7 @@ def complete_auth(auth_code):
         scopes = GoogleAuthManager.SCOPES
 
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
-        flow.redirect_uri = 'http://localhost:8080'
+        flow.redirect_uri = "http://localhost:8080"
 
         # Exchange authorization code for credentials
         flow.fetch_token(code=auth_code)
@@ -32,7 +35,7 @@ def complete_auth(auth_code):
 
         # Save credentials
         token_path.parent.mkdir(exist_ok=True)
-        with open(token_path, 'wb') as token:
+        with open(token_path, "wb") as token:
             pickle.dump(creds, token)
 
         print("✅ Authentication completed successfully!")
@@ -48,6 +51,7 @@ def complete_auth(auth_code):
         print("   1. Copied the full authorization code correctly")
         print("   2. Didn't include extra characters or spaces")
         print("   3. Used the code quickly (they expire fast)")
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:

--- a/scripts/complete_auth_limited.py
+++ b/scripts/complete_auth_limited.py
@@ -2,84 +2,89 @@
 """Complete authentication with limited scopes that were actually granted."""
 
 import os
-import sys
 import pickle
+import sys
 from pathlib import Path
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 # Use only the scopes that were actually granted
 GRANTED_SCOPES = [
-    'https://www.googleapis.com/auth/calendar',
-    'https://www.googleapis.com/auth/documents', 
-    'https://www.googleapis.com/auth/drive.file',
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive.file",
 ]
+
 
 def main():
     """Complete authentication with the scopes that were actually granted."""
     if len(sys.argv) != 2:
         print("Usage: python complete_auth_limited.py <authorization_code>")
         return 1
-    
+
     auth_code = sys.argv[1].strip()
-    credentials_path = 'config/credentials.json'
-    token_path = Path('config/token.pickle')
-    
+    credentials_path = "config/credentials.json"
+    token_path = Path("config/token.pickle")
+
     if not os.path.exists(credentials_path):
         print(f"❌ Credentials file not found: {credentials_path}")
         return 1
-    
+
     try:
         print("🔄 Exchanging authorization code for tokens...")
         print("📋 Using granted scopes:")
         for scope in GRANTED_SCOPES:
             print(f"  ✅ {scope}")
-        
+
         # Create flow with only granted scopes
-        flow = InstalledAppFlow.from_client_secrets_file(credentials_path, GRANTED_SCOPES)
-        flow.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
-        
+        flow = InstalledAppFlow.from_client_secrets_file(
+            credentials_path, GRANTED_SCOPES
+        )
+        flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+
         # Exchange code for tokens
         flow.fetch_token(code=auth_code)
         creds = flow.credentials
-        
+
         # Save credentials
         token_path.parent.mkdir(exist_ok=True)
-        with open(token_path, 'wb') as token:
+        with open(token_path, "wb") as token:
             pickle.dump(creds, token)
-            
-        print(f"✅ Authentication successful!")
+
+        print("✅ Authentication successful!")
         print(f"💾 Token saved to: {token_path}")
         print(f"🔑 Token valid: {creds.valid}")
-        
-        if hasattr(creds, 'refresh_token') and creds.refresh_token:
+
+        if hasattr(creds, "refresh_token") and creds.refresh_token:
             print("🔄 Refresh token available - automatic renewal enabled")
         else:
             print("⚠️  No refresh token - may need to re-authenticate periodically")
-        
+
         print("\n📝 Note: Limited functionality available:")
-        print("  ✅ Google Calendar - Full functionality")  
+        print("  ✅ Google Calendar - Full functionality")
         print("  ✅ Google Docs - Create documents")
         print("  ✅ Google Drive - File management")
         print("  ❌ Gmail - Not authorized (send/read emails)")
-        print("  ❌ Google Sheets - Not authorized") 
+        print("  ❌ Google Sheets - Not authorized")
         print("  ❌ Google Slides - Not authorized")
-        
+
         print("\n🔄 To enable Gmail/Sheets/Slides, you'll need to:")
         print("1. Re-run the OAuth flow")
         print("2. Grant ALL requested permissions")
         print("3. Make sure to click 'Allow' for Gmail access")
-            
+
     except Exception as e:
         print(f"❌ Authentication failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/configure_scopes.py
+++ b/scripts/configure_scopes.py
@@ -5,10 +5,10 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Dict, Set
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from utils.scope_manager import ScopeManager
 
@@ -41,62 +41,66 @@ class ScopeConfigurator:
         print(f"File exists: {'✅' if config_summary['config_exists'] else '❌'}")
         print(f"Configuration valid: {'✅' if config_summary['is_valid'] else '❌'}")
 
-        if not config_summary['is_valid']:
+        if not config_summary["is_valid"]:
             print("❌ Configuration errors:")
-            for error in config_summary['errors']:
+            for error in config_summary["errors"]:
                 print(f"   • {error}")
 
         print()
         print("Enabled services:")
-        for service in config_summary['enabled_services']:
-            description = config_summary['service_descriptions'].get(service, '')
+        for service in config_summary["enabled_services"]:
+            description = config_summary["service_descriptions"].get(service, "")
             print(f"   ✅ {service}: {description}")
 
         print()
         print("Required scopes:")
-        for scope in config_summary['required_scopes']:
+        for scope in config_summary["required_scopes"]:
             print(f"   • {scope}")
         print()
 
     def display_available_services(self) -> Dict[str, Dict]:
         """Display available services and return service info."""
         services = {
-            'calendar': {
-                'name': 'Google Calendar',
-                'description': 'Create, view, and manage calendar events',
-                'dependencies': []
+            "calendar": {
+                "name": "Google Calendar",
+                "description": "Create, view, and manage calendar events",
+                "dependencies": [],
             },
-            'gmail': {
-                'name': 'Gmail',
-                'description': 'Send, read, and manage email messages',
-                'dependencies': []
+            "gmail": {
+                "name": "Gmail",
+                "description": "Send, read, and manage email messages",
+                "dependencies": [],
             },
-            'docs': {
-                'name': 'Google Docs',
-                'description': 'Create and edit Google Documents',
-                'dependencies': ['drive']
+            "docs": {
+                "name": "Google Docs",
+                "description": "Create and edit Google Documents",
+                "dependencies": ["drive"],
             },
-            'sheets': {
-                'name': 'Google Sheets',
-                'description': 'Create and edit Google Spreadsheets (Coming Soon)',
-                'dependencies': ['drive']
+            "sheets": {
+                "name": "Google Sheets",
+                "description": "Create and edit Google Spreadsheets (Coming Soon)",
+                "dependencies": ["drive"],
             },
-            'slides': {
-                'name': 'Google Slides',
-                'description': 'Create and edit Google Presentations (Coming Soon)',
-                'dependencies': ['drive']
+            "slides": {
+                "name": "Google Slides",
+                "description": "Create and edit Google Presentations (Coming Soon)",
+                "dependencies": ["drive"],
             },
-            'drive': {
-                'name': 'Google Drive',
-                'description': 'Access Google Drive files (required for Docs/Sheets/Slides)',
-                'dependencies': []
-            }
+            "drive": {
+                "name": "Google Drive",
+                "description": "Access Google Drive files (required for Docs/Sheets/Slides)",
+                "dependencies": [],
+            },
         }
 
         print("📝 Available Services:")
         print("-" * 20)
         for service_id, info in services.items():
-            deps = f" (requires: {', '.join(info['dependencies'])})" if info['dependencies'] else ""
+            deps = (
+                f" (requires: {', '.join(info['dependencies'])})"
+                if info["dependencies"]
+                else ""
+            )
             print(f"   {service_id}: {info['name']} - {info['description']}{deps}")
         print()
 
@@ -108,9 +112,11 @@ class ScopeConfigurator:
 
         print("🔧 Service Selection:")
         print("-" * 18)
-        print("Enter services to enable (space-separated), or 'default' for recommended:")
+        print(
+            "Enter services to enable (space-separated), or 'default' for recommended:"
+        )
         print(f"Current: {' '.join(sorted(current_enabled))}")
-        print(f"Recommended: calendar gmail docs drive")
+        print("Recommended: calendar gmail docs drive")
         print(f"Available: {' '.join(sorted(available_services.keys()))}")
         print()
 
@@ -122,7 +128,7 @@ class ScopeConfigurator:
                 continue
 
             if user_input == "default":
-                selected = {'calendar', 'gmail', 'docs', 'drive'}
+                selected = {"calendar", "gmail", "docs", "drive"}
                 break
 
             # Parse space-separated services
@@ -139,13 +145,15 @@ class ScopeConfigurator:
 
         return selected
 
-    def validate_dependencies(self, selected: Set[str], available_services: Dict) -> Set[str]:
+    def validate_dependencies(
+        self, selected: Set[str], available_services: Dict
+    ) -> Set[str]:
         """Validate and add required dependencies."""
         final_selection = set(selected)
         added_deps = set()
 
         for service in selected:
-            deps = available_services[service]['dependencies']
+            deps = available_services[service]["dependencies"]
             for dep in deps:
                 if dep not in final_selection:
                     final_selection.add(dep)
@@ -170,9 +178,9 @@ class ScopeConfigurator:
 
         while True:
             confirm = input("Confirm this configuration? (y/n): ").strip().lower()
-            if confirm in ['y', 'yes']:
+            if confirm in ["y", "yes"]:
                 return True
-            elif confirm in ['n', 'no']:
+            elif confirm in ["n", "no"]:
                 return False
             else:
                 print("❌ Please enter 'y' or 'n'")
@@ -182,22 +190,22 @@ class ScopeConfigurator:
         try:
             # Get current config or use default
             if self.config_path.exists():
-                with open(self.config_path, 'r') as f:
+                with open(self.config_path, "r") as f:
                     config = json.load(f)
             else:
                 config = self.scope_manager._get_default_config()
 
             # Update enabled services
-            config['enabled_services'] = {
+            config["enabled_services"] = {
                 service: service in enabled_services
-                for service in config['enabled_services'].keys()
+                for service in config["enabled_services"].keys()
             }
 
             # Ensure config directory exists
             self.config_path.parent.mkdir(exist_ok=True)
 
             # Save config
-            with open(self.config_path, 'w') as f:
+            with open(self.config_path, "w") as f:
                 json.dump(config, f, indent=2)
 
             print(f"✅ Configuration saved to {self.config_path}")
@@ -219,8 +227,10 @@ class ScopeConfigurator:
             print("Delete existing authentication token?")
 
             while True:
-                cleanup = input("Delete token to force re-auth? (y/n): ").strip().lower()
-                if cleanup in ['y', 'yes']:
+                cleanup = (
+                    input("Delete token to force re-auth? (y/n): ").strip().lower()
+                )
+                if cleanup in ["y", "yes"]:
                     try:
                         token_path.unlink()
                         print(f"✅ Deleted {token_path}")
@@ -228,7 +238,7 @@ class ScopeConfigurator:
                     except Exception as e:
                         print(f"❌ Failed to delete token: {e}")
                     break
-                elif cleanup in ['n', 'no']:
+                elif cleanup in ["n", "no"]:
                     print("   Token kept - you may need to manually delete it later")
                     break
                 else:
@@ -242,7 +252,9 @@ class ScopeConfigurator:
 
             available_services = self.display_available_services()
             selected_services = self.get_user_selection(available_services)
-            final_services = self.validate_dependencies(selected_services, available_services)
+            final_services = self.validate_dependencies(
+                selected_services, available_services
+            )
 
             if self.confirm_selection(final_services, available_services):
                 if self.save_configuration(final_services):

--- a/scripts/get_auth_url.py
+++ b/scripts/get_auth_url.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
 """Get Google OAuth URL for manual authentication in WSL."""
 
-import sys
 import os
-sys.path.append('src')
+import sys
+
+sys.path.append("src")
 
 from google_auth_oauthlib.flow import InstalledAppFlow
+
 from auth.google_auth import GoogleAuthManager
+
 
 def get_auth_url():
     """Get authentication URL for manual browser opening."""
-    credentials_path = 'config/credentials.json'
+    credentials_path = "config/credentials.json"
     if not os.path.exists(credentials_path):
         print(f"❌ Credentials file not found: {credentials_path}")
-        print("Please download OAuth2 credentials from Google Cloud Console and save as config/credentials.json")
+        print(
+            "Please download OAuth2 credentials from Google Cloud Console "
+            "and save as config/credentials.json"
+        )
         return
 
     # Same scopes as GoogleAuthManager
@@ -21,11 +27,10 @@ def get_auth_url():
 
     try:
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, scopes)
-        flow.redirect_uri = 'http://localhost:8080'  # Use a standard port
+        flow.redirect_uri = "http://localhost:8080"  # Use a standard port
 
         auth_url, _ = flow.authorization_url(
-            access_type='offline',
-            include_granted_scopes='true'
+            access_type="offline", include_granted_scopes="true"
         )
 
         print("🔗 GOOGLE AUTHENTICATION REQUIRED")
@@ -45,6 +50,7 @@ def get_auth_url():
 
     except Exception as e:
         print(f"❌ Error generating auth URL: {e}")
+
 
 if __name__ == "__main__":
     get_auth_url()

--- a/scripts/get_folder_id.py
+++ b/scripts/get_folder_id.py
@@ -2,44 +2,47 @@
 """Helper script to create a folder and get its ID."""
 
 import asyncio
-import sys
-from src.auth.google_auth import GoogleAuthManager
+
 from googleapiclient.discovery import build
+
+from src.auth.google_auth import GoogleAuthManager
+
 
 async def create_mcp_folder():
     """Create a dedicated folder for MCP documents."""
-    
+
     # Initialize auth
     auth_manager = GoogleAuthManager()
     await auth_manager.initialize()
-    
+
     # Get Drive service
-    drive_service = build('drive', 'v3', credentials=auth_manager.get_credentials())
-    
+    drive_service = build("drive", "v3", credentials=auth_manager.get_credentials())
+
     # Create folder
     folder_metadata = {
-        'name': 'Claude MCP Documents',
-        'mimeType': 'application/vnd.google-apps.folder',
-        'description': 'Documents created by Claude MCP integration'
+        "name": "Claude MCP Documents",
+        "mimeType": "application/vnd.google-apps.folder",
+        "description": "Documents created by Claude MCP integration",
     }
-    
+
     try:
         folder = drive_service.files().create(body=folder_metadata).execute()
-        folder_id = folder.get('id')
-        
-        print(f"✓ Created folder: 'Claude MCP Documents'")
+        folder_id = folder.get("id")
+
+        print("✓ Created folder: 'Claude MCP Documents'")
         print(f"✓ Folder ID: {folder_id}")
         print(f"✓ Folder URL: https://drive.google.com/drive/folders/{folder_id}")
         print()
         print("Add this to your .env file:")
         print(f"GOOGLE_DEFAULT_FOLDER={folder_id}")
         print(f"GOOGLE_ALLOWED_FOLDERS={folder_id}")
-        
+
         return folder_id
-        
+
     except Exception as e:
         print(f"Error creating folder: {e}")
         return None
+
 
 if __name__ == "__main__":
     folder_id = asyncio.run(create_mcp_folder())

--- a/scripts/manual_auth.py
+++ b/scripts/manual_auth.py
@@ -2,33 +2,33 @@
 """Manual authentication script for Google Workspace MCP."""
 
 import os
-import sys
 import pickle
+import sys
 from pathlib import Path
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 
 SCOPES = [
-    'https://www.googleapis.com/auth/calendar',
-    'https://www.googleapis.com/auth/gmail.send', 
-    'https://www.googleapis.com/auth/gmail.readonly',
-    'https://www.googleapis.com/auth/gmail.compose',
-    'https://www.googleapis.com/auth/gmail.modify',
-    'https://www.googleapis.com/auth/documents',
-    'https://www.googleapis.com/auth/spreadsheets', 
-    'https://www.googleapis.com/auth/presentations',
-    'https://www.googleapis.com/auth/drive.file',
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.compose",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/presentations",
+    "https://www.googleapis.com/auth/drive.file",
 ]
+
 
 def main():
     """Manually authenticate with Google APIs."""
-    credentials_path = 'config/credentials.json'
-    token_path = Path('config/token.pickle')
-    
+    credentials_path = "config/credentials.json"
+    token_path = Path("config/token.pickle")
+
     if not os.path.exists(credentials_path):
         print(f"❌ Credentials file not found: {credentials_path}")
         print("Please download OAuth2 credentials from Google Cloud Console:")
@@ -36,48 +36,52 @@ def main():
         print("2. Create OAuth client ID (Desktop application)")
         print("3. Download and save as config/credentials.json")
         return
-    
+
     try:
         print("🔄 Starting OAuth2 authentication flow...")
         print(f"📁 Using credentials: {credentials_path}")
         print(f"💾 Token will be saved to: {token_path}")
         print(f"🔐 Required scopes: {len(SCOPES)} scopes")
-        
+
         # Create flow
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
-        
+
         print("\n🌐 Opening browser for authentication...")
         print("⚠️  If browser doesn't open automatically, copy the URL from the console")
-        
+
         # Run local server for OAuth callback
         creds = flow.run_local_server(
             port=0,  # Use random available port
-            prompt='consent',  # Always show consent screen
-            authorization_prompt_message='Please visit this URL to authorize the application: {url}',
-            success_message='Authentication successful! You can close this browser tab.'
+            prompt="consent",  # Always show consent screen
+            authorization_prompt_message=(
+                "Please visit this URL to authorize the application: {url}"
+            ),
+            success_message="Authentication successful! You can close this browser tab.",
         )
-        
+
         # Save credentials
         token_path.parent.mkdir(exist_ok=True)
-        with open(token_path, 'wb') as token:
+        with open(token_path, "wb") as token:
             pickle.dump(creds, token)
-            
-        print(f"✅ Authentication successful!")
+
+        print("✅ Authentication successful!")
         print(f"💾 Token saved to: {token_path}")
         print(f"🔑 Token valid: {creds.valid}")
-        
-        if hasattr(creds, 'refresh_token') and creds.refresh_token:
+
+        if hasattr(creds, "refresh_token") and creds.refresh_token:
             print("🔄 Refresh token available - automatic renewal enabled")
         else:
             print("⚠️  No refresh token - may need to re-authenticate periodically")
-            
+
     except Exception as e:
         print(f"❌ Authentication failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/manual_auth_nobrowser.py
+++ b/scripts/manual_auth_nobrowser.py
@@ -2,55 +2,53 @@
 """Manual authentication script for Google Workspace MCP - No browser version."""
 
 import os
-import sys
 import pickle
+import sys
 from pathlib import Path
 
 # Add src to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from google_auth_oauthlib.flow import InstalledAppFlow
-from google.auth.transport.requests import Request
 
 SCOPES = [
-    'https://www.googleapis.com/auth/calendar',
-    'https://www.googleapis.com/auth/gmail.send', 
-    'https://www.googleapis.com/auth/gmail.readonly',
-    'https://www.googleapis.com/auth/gmail.compose',
-    'https://www.googleapis.com/auth/gmail.modify',
-    'https://www.googleapis.com/auth/documents',
-    'https://www.googleapis.com/auth/spreadsheets', 
-    'https://www.googleapis.com/auth/presentations',
-    'https://www.googleapis.com/auth/drive.file',
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.compose",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/presentations",
+    "https://www.googleapis.com/auth/drive.file",
 ]
+
 
 def main():
     """Manually authenticate with Google APIs without browser."""
-    credentials_path = 'config/credentials.json'
-    token_path = Path('config/token.pickle')
-    
+    credentials_path = "config/credentials.json"
+    token_path = Path("config/token.pickle")
+
     if not os.path.exists(credentials_path):
         print(f"❌ Credentials file not found: {credentials_path}")
         return 1
-    
+
     try:
         print("🔄 Starting manual OAuth2 authentication...")
         print("📋 Required scopes:")
         for i, scope in enumerate(SCOPES, 1):
             print(f"  {i}. {scope}")
-        
+
         # Create flow
         flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
-        
+
         # Get authorization URL with manual redirect URI
-        flow.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'  # Out-of-band flow
+        flow.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"  # Out-of-band flow
         auth_url, _ = flow.authorization_url(
-            access_type='offline',
-            prompt='consent',
-            include_granted_scopes='true'
+            access_type="offline", prompt="consent", include_granted_scopes="true"
         )
-        
-        print(f"\n🌐 Please visit this URL in your browser:")
+
+        print("\n🌐 Please visit this URL in your browser:")
         print(f"\n{auth_url}\n")
         print("📋 Steps:")
         print("1. Copy the URL above")
@@ -59,40 +57,42 @@ def main():
         print("4. Grant permissions to all requested scopes")
         print("5. Copy the authorization code from the success page")
         print("6. Paste it below")
-        
+
         # Get authorization code from user
         auth_code = input("\n🔑 Enter authorization code: ").strip()
-        
+
         if not auth_code:
             print("❌ No authorization code provided")
             return 1
-            
+
         print("🔄 Exchanging authorization code for tokens...")
         flow.fetch_token(code=auth_code)
-        
+
         creds = flow.credentials
-        
+
         # Save credentials
         token_path.parent.mkdir(exist_ok=True)
-        with open(token_path, 'wb') as token:
+        with open(token_path, "wb") as token:
             pickle.dump(creds, token)
-            
-        print(f"✅ Authentication successful!")
+
+        print("✅ Authentication successful!")
         print(f"💾 Token saved to: {token_path}")
         print(f"🔑 Token valid: {creds.valid}")
-        
-        if hasattr(creds, 'refresh_token') and creds.refresh_token:
+
+        if hasattr(creds, "refresh_token") and creds.refresh_token:
             print("🔄 Refresh token available - automatic renewal enabled")
         else:
             print("⚠️  No refresh token - may need to re-authenticate periodically")
-            
+
     except Exception as e:
         print(f"❌ Authentication failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Pre-commit hook for Python projects
+# Copy this to .git/hooks/pre-commit and make executable: chmod +x .git/hooks/pre-commit
+
+set -e  # Exit on first error
+
+echo "🔍 Running pre-commit checks for Python..."
+
+# Check if we're in a Python project
+if [ ! -f "requirements.txt" ] && [ ! -f "pyproject.toml" ] && [ ! -f "setup.py" ]; then
+    echo "⚠️  Not a Python project, skipping Python checks"
+    exit 0
+fi
+
+# Activate virtual environment if it exists
+if [ -d "venv" ] && [ -f "venv/bin/activate" ]; then
+    echo "  Activating virtual environment..."
+    source venv/bin/activate
+elif [ -d ".venv" ] && [ -f ".venv/bin/activate" ]; then
+    echo "  Activating virtual environment..."
+    source .venv/bin/activate
+fi
+
+# Color output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Track if any check fails
+CHECKS_FAILED=0
+
+# Function to run check and track failures
+run_check() {
+    local check_name=$1
+    local check_command=$2
+
+    echo -n "  ${check_name}... "
+
+    if eval "$check_command" > /dev/null 2>&1; then
+        echo -e "${GREEN}✓${NC}"
+        return 0
+    else
+        echo -e "${RED}✗${NC}"
+        CHECKS_FAILED=1
+        return 1
+    fi
+}
+
+# Determine source directories
+SRC_DIRS=""
+[ -d "src" ] && SRC_DIRS="$SRC_DIRS src"
+[ -d "tests" ] && SRC_DIRS="$SRC_DIRS tests"
+[ -d "app" ] && SRC_DIRS="$SRC_DIRS app"
+[ -d "scripts" ] && SRC_DIRS="$SRC_DIRS scripts"
+
+if [ -z "$SRC_DIRS" ]; then
+    echo -e "${YELLOW}⚠️  No source directories found (src/, tests/, app/, scripts/), skipping checks${NC}"
+    exit 0
+fi
+
+echo "  Checking directories: $SRC_DIRS"
+
+# 1. Code formatting with Black (if installed)
+if command -v black &> /dev/null; then
+    run_check "Black formatting" "black --check $SRC_DIRS"
+else
+    echo -e "  ${YELLOW}Black not installed, skipping formatting check${NC}"
+fi
+
+# 2. Linting with Ruff (if installed)
+if command -v ruff &> /dev/null; then
+    run_check "Ruff linting" "ruff check $SRC_DIRS"
+else
+    echo -e "  ${YELLOW}Ruff not installed, skipping linting check${NC}"
+fi
+
+# 3. Type checking with mypy (if installed)
+if command -v mypy &> /dev/null; then
+    # Only check src/ for type hints, tests often have issues
+    if [ -d "src" ]; then
+        run_check "Mypy type checking" "mypy src --ignore-missing-imports"
+    fi
+else
+    echo -e "  ${YELLOW}Mypy not installed, skipping type check${NC}"
+fi
+
+# 4. Security check with bandit (if installed)
+if command -v bandit &> /dev/null; then
+    run_check "Bandit security scan" "bandit -r $SRC_DIRS -ll -q"
+else
+    echo -e "  ${YELLOW}Bandit not installed, skipping security scan${NC}"
+fi
+
+# 5. Import sorting handled by Ruff (included in step 2)
+
+# Final result
+echo ""
+if [ $CHECKS_FAILED -eq 0 ]; then
+    echo -e "${GREEN}✅ All pre-commit checks passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}❌ Pre-commit checks failed. Please fix the issues above.${NC}"
+    echo ""
+    echo "Quick fixes:"
+    echo "  black $SRC_DIRS              # Auto-format code"
+    echo "  ruff check --fix $SRC_DIRS   # Auto-fix linting and import issues"
+    echo "  mypy src                     # View type issues"
+    echo ""
+    echo "To skip pre-commit hooks (not recommended): git commit --no-verify"
+    exit 1
+fi

--- a/scripts/test_integration.py
+++ b/scripts/test_integration.py
@@ -10,8 +10,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from auth.google_auth import GoogleAuthManager
 from tools.calendar import GoogleCalendarTools
-from tools.gmail import GmailTools
 from tools.docs import GoogleDocsTools
+from tools.gmail import GmailTools
 
 
 async def test_authentication():
@@ -31,12 +31,12 @@ async def test_calendar(auth_manager):
     """Test calendar functionality."""
     print("\nTesting Calendar Tools...")
     calendar_tools = GoogleCalendarTools(auth_manager)
-    
+
     try:
         # List calendars
         result = await calendar_tools.list_calendars({})
         print(f"✓ Found {result['count']} calendars")
-        for cal in result['calendars'][:3]:  # Show first 3
+        for cal in result["calendars"][:3]:  # Show first 3
             print(f"  - {cal['summary']} (ID: {cal['id']})")
     except Exception as e:
         print(f"✗ Calendar test failed: {e}")
@@ -46,15 +46,12 @@ async def test_gmail(auth_manager):
     """Test Gmail functionality."""
     print("\nTesting Gmail Tools...")
     gmail_tools = GmailTools(auth_manager)
-    
+
     try:
         # Search for recent emails
-        result = await gmail_tools.search_emails({
-            "query": "is:sent",
-            "max_results": 3
-        })
+        result = await gmail_tools.search_emails({"query": "is:sent", "max_results": 3})
         print(f"✓ Found {result['count']} sent emails")
-        for msg in result['messages']:
+        for msg in result["messages"]:
             print(f"  - {msg['subject']} (to: {msg['to']})")
     except Exception as e:
         print(f"✗ Gmail test failed: {e}")
@@ -63,8 +60,8 @@ async def test_gmail(auth_manager):
 async def test_docs(auth_manager):
     """Test Google Docs functionality."""
     print("\nTesting Google Docs Tools...")
-    docs_tools = GoogleDocsTools(auth_manager)
-    
+    _ = GoogleDocsTools(auth_manager)  # noqa: F841
+
     try:
         # Note: This would actually create a document
         print("✓ Google Docs tools initialized")
@@ -77,18 +74,18 @@ async def main():
     """Run all tests."""
     print("Google Workspace MCP Test Suite")
     print("==============================")
-    
+
     # Test authentication
     auth_manager = await test_authentication()
     if not auth_manager:
         print("\nAuthentication failed. Please run setup.sh first.")
         return
-    
+
     # Test each service
     await test_calendar(auth_manager)
     await test_gmail(auth_manager)
     await test_docs(auth_manager)
-    
+
     print("\n✓ All tests completed!")
     print("\nNext steps:")
     print("1. Configure Claude Desktop with the MCP server")

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,5 +2,24 @@ sonar.projectKey=adamkwhite_google-workspace-mcp
 sonar.organization=adamkwhite
 sonar.python.version=3.11
 sonar.python.coverage.reportPaths=coverage.xml
-sonar.sources=.
-sonar.exclusions=**/*test*/**,**/__pycache__/**,venv/**,config/**,scripts/**,logs/**,archive/**
+
+# Only scan source code directory
+sonar.sources=src
+
+# Test directory (for analysis but separate from sources)
+sonar.tests=tests
+
+# Exclude from analysis
+sonar.exclusions=**/__pycache__/**
+
+# Exclude from coverage calculations
+sonar.coverage.exclusions=\
+  **/*test*.py,\
+  **/test_*.py,\
+  tests/**,\
+  scripts/**,\
+  setup.py,\
+  .github/**,\
+  *.json,\
+  *.toml,\
+  *.md


### PR DESCRIPTION
## Summary
Fixes SonarCloud configuration to exclude build/config files from test coverage calculations.

## Problem
SonarCloud was showing 0% coverage for files that don't need testing:
- `.github/workflows` (95 lines, CI configs)
- `setup.py` (79 lines, build script)  
- `claude-mcp-config.json` (config file)
- Test files themselves

These cluttered the coverage report and made it hard to see actual source code coverage.

## Solution
Updated `sonar-project.properties`:

```properties
# Only scan source code directory
sonar.sources=src

# Test directory (separate from sources)
sonar.tests=tests

# Exclude from coverage calculations
sonar.coverage.exclusions=\
  tests/**,\
  scripts/**,\
  setup.py,\
  .github/**,\
  *.json,\
  *.toml,\
  *.md
```

## Impact
**Before**: Coverage report included config/build files at 0%  
**After**: Only `src/` directory included in coverage metrics (84.2%)

SonarCloud will now accurately reflect source code coverage without noise from configuration files.

## Testing
- ✅ Configuration syntax valid
- ✅ Will verify on next SonarCloud scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)