### PR TITLE
Fix Starlette DoS vulnerability and workflow issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*) --allowed-bots "claude"'
+          claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 # Google Workspace MCP Server Requirements
 
 # MCP Framework
-mcp>=0.1.0
+mcp>=1.22.0
+
+# Security: Pin starlette to patched version (CVE-2025-62727)
+# https://github.com/advisories/GHSA-7f5h-v6xp-fcq8
+starlette>=0.49.1
 
 # Google API Client Libraries
 google-api-python-client>=2.88.0


### PR DESCRIPTION
## Summary
- 🔒 Fix high-severity DoS vulnerability in Starlette (CVE-2025-62727)
- 🛠️ Fix invalid `--allowed-bots` flag in Claude Code workflow
- ⬆️ Upgrade MCP framework from 0.9.1 to 1.22.0

## Security Fix (CVE-2025-62727)
**Vulnerability:** O(n^2) DoS via crafted Range headers in `starlette.responses.FileResponse`
- **Severity:** High (CVSS 7.5)
- **Affected:** starlette >= 0.39.0, <= 0.49.0
- **Fixed:** starlette >= 0.49.1
- **Current:** starlette 0.50.0 ✅

**Impact:** Unauthenticated attackers can exhaust CPU with single HTTP request containing crafted Range header, affecting any Starlette app serving files via FileResponse or StaticFiles.

**Changes:**
- Upgraded `mcp` from `>=0.1.0` to `>=1.22.0`
- Pinned `starlette` to `>=0.49.1` (patched version)
- Added security comments in requirements.txt

## Workflow Fix
**Issue:** Claude Code workflow had invalid `--allowed-bots "claude"` flag
- Removed unsupported flag that caused immediate workflow failures
- Kept valid flags: `--model` and `--allowed-tools`

## Test Plan
- [x] All 201 tests pass with upgraded dependencies
- [x] No breaking changes from MCP 0.9.1 → 1.22.0 upgrade
- [x] Pre-commit hooks passed (Black, Ruff, Mypy, Bandit, Gitleaks)
- [x] Verified starlette 0.50.0 installed (above patched 0.49.1)
- [ ] CI/CD pipelines pass
- [ ] Dependabot alert #2 automatically closes after merge

## References
- Dependabot Alert: https://github.com/adamkwhite/google-workspace-mcp/security/dependabot/2
- Advisory: https://github.com/advisories/GHSA-7f5h-v6xp-fcq8
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-62727

🤖 Generated with [Claude Code](https://claude.com/claude-code)