### PR TITLE
fix: correct Claude Desktop config paths and venv conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,25 @@ Works with regular Gmail accounts - no Google Workspace subscription required.
 - Dependencies are automatically handled (e.g., Docs requires Drive)
 - Scope changes trigger automatic re-authentication
 
+## MCP Configuration Guidance (for AI agents)
+
+When helping a user write their Claude Desktop `claude_desktop_config.json` for this project, do not copy example paths verbatim. The templates in `config/` use `<ABSOLUTE_PATH_TO_REPO>` as a placeholder that the user must replace with the absolute path to their clone. Previous agent-generated configs have failed by pasting `/home/user/google-workspace-mcp` (a placeholder) into the live config, which silently breaks the MCP connection because no such directory exists.
+
+Before producing a config:
+1. Get the user's actual absolute path — ask them, or run `pwd` from the repo root if you have shell access. Never guess.
+2. Check which virtualenv directory exists: `ls -d .venv venv 2>/dev/null`. The setup script creates `.venv/`, but older clones may have `venv/`. The `scripts/run_server.sh` wrapper handles both; a direct config line must pick one.
+3. For Windows Claude Desktop with WSL, use the `wsl.exe` form from `config/claude_desktop_config.json`. For native Linux/macOS, drop the `wsl.exe` wrapper and call the venv Python directly (see `config/claude_desktop_config_alternative.json`).
+4. After the user updates the config, Claude Desktop must be fully quit and relaunched — MCP servers only load at startup.
+
 ## Essential Commands
 
 ### Development Setup
 ```bash
-# Initial setup (creates venv, installs deps, guides OAuth2 setup)
+# Initial setup (creates .venv, installs deps, guides OAuth2 setup)
 ./scripts/setup.sh
 
 # Activate virtual environment (required for all development)
-source venv/bin/activate
+source .venv/bin/activate
 
 # Run MCP server directly for testing
 python src/server.py
@@ -118,7 +128,7 @@ ls -la config/credentials.json
 
 ## Development Notes
 
-- Always activate virtual environment: `source venv/bin/activate`
+- Always activate virtual environment: `source .venv/bin/activate`
 - OAuth2 requires browser for initial authentication
 - Use `python scripts/configure_scopes.py` for easy service configuration
 - Tool registration is conditional based on config/scopes.json

--- a/README.md
+++ b/README.md
@@ -115,20 +115,22 @@ This MCP server follows the principle of least privilege by intentionally exclud
    - Download as `config/credentials.json`
 
 5. **Configure Claude Desktop**:
-   Add to your Claude Desktop config:
+   Add to your Claude Desktop config, replacing `<ABSOLUTE_PATH_TO_REPO>` with the absolute path to your clone (e.g., `/home/you/Code/google-workspace-mcp`). On Windows Claude Desktop with WSL:
    ```json
    {
      "mcpServers": {
        "google-workspace": {
-         "command": "python",
-         "args": ["/home/adam/Code/google-workspace-mcp/src/server.py"],
-         "env": {
-           "PYTHONPATH": "/home/adam/Code/google-workspace-mcp/src"
-         }
+         "command": "wsl.exe",
+         "args": [
+           "-d", "Ubuntu",
+           "bash", "--", "-c",
+           "cd <ABSOLUTE_PATH_TO_REPO> && source .venv/bin/activate && PYTHONPATH=<ABSOLUTE_PATH_TO_REPO>/src python src/server.py"
+         ]
        }
      }
    }
    ```
+   See `config/claude_desktop_config.json` for the template and `config/claude_desktop_config_alternative.json` for a bash-free alternative. On non-Windows hosts, drop the `wsl.exe` wrapper and call the venv Python directly.
 
 6. **First run** will open browser for authentication (only for enabled services)
 
@@ -337,7 +339,7 @@ All quotas are per-user and more than sufficient for personal use:
 
 ```bash
 # Activate virtual environment
-source venv/bin/activate
+source .venv/bin/activate
 
 # Run tests
 pytest tests/

--- a/config/claude_config_example.json
+++ b/config/claude_config_example.json
@@ -1,12 +1,13 @@
 {
+  "_comment": "TEMPLATE. Minimal example assuming `python` on PATH points to a Python with the project's deps installed (not recommended — prefer claude_desktop_config.json or claude_desktop_config_alternative.json). Replace <ABSOLUTE_PATH_TO_REPO> with the absolute path to your clone.",
   "mcpServers": {
     "google-workspace": {
       "command": "python",
       "args": [
-        "/home/adam/Code/google-workspace-mcp/src/server.py"
+        "<ABSOLUTE_PATH_TO_REPO>/src/server.py"
       ],
       "env": {
-        "PYTHONPATH": "/home/adam/Code/google-workspace-mcp/src"
+        "PYTHONPATH": "<ABSOLUTE_PATH_TO_REPO>/src"
       }
     }
   }

--- a/config/claude_desktop_config.json
+++ b/config/claude_desktop_config.json
@@ -1,11 +1,12 @@
 {
+  "_comment": "TEMPLATE. Replace <ABSOLUTE_PATH_TO_REPO> with the absolute path to your clone (e.g., /home/you/Code/google-workspace-mcp). On Windows Claude Desktop with WSL, paste this into %APPDATA%\\Claude\\claude_desktop_config.json after substitution.",
   "mcpServers": {
     "google-workspace": {
-      "command": "wsl",
+      "command": "wsl.exe",
       "args": [
-        "bash", 
-        "-c", 
-        "cd /home/adam/Code/google-workspace-mcp && source venv/bin/activate && python src/server.py"
+        "-d", "Ubuntu",
+        "bash", "--", "-c",
+        "cd <ABSOLUTE_PATH_TO_REPO> && source .venv/bin/activate && PYTHONPATH=<ABSOLUTE_PATH_TO_REPO>/src python src/server.py"
       ]
     }
   }

--- a/config/claude_desktop_config_alternative.json
+++ b/config/claude_desktop_config_alternative.json
@@ -1,12 +1,13 @@
 {
+  "_comment": "TEMPLATE. Alternative that calls the venv Python directly (no bash wrapper). Replace <ABSOLUTE_PATH_TO_REPO> with the absolute path to your clone. Use this if the bash -c form in claude_desktop_config.json doesn't work for your setup.",
   "mcpServers": {
     "google-workspace": {
-      "command": "/home/adam/Code/google-workspace-mcp/venv/bin/python",
+      "command": "<ABSOLUTE_PATH_TO_REPO>/.venv/bin/python",
       "args": [
-        "/home/adam/Code/google-workspace-mcp/src/server.py"
+        "<ABSOLUTE_PATH_TO_REPO>/src/server.py"
       ],
       "env": {
-        "PYTHONPATH": "/home/adam/Code/google-workspace-mcp/src"
+        "PYTHONPATH": "<ABSOLUTE_PATH_TO_REPO>/src"
       }
     }
   }

--- a/scripts/run_server.sh
+++ b/scripts/run_server.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
-# Wrapper script to run the MCP server with the virtual environment
+# Wrapper script to run the MCP server with the virtual environment.
 
-# Get the directory where this script is located
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$( cd "$DIR/.." && pwd )"
 
-# Activate the virtual environment
-source "$DIR/venv/bin/activate"
+if [ -d "$ROOT/.venv" ]; then
+    source "$ROOT/.venv/bin/activate"
+elif [ -d "$ROOT/venv" ]; then
+    source "$ROOT/venv/bin/activate"
+else
+    echo "Error: no virtual environment found at $ROOT/.venv or $ROOT/venv" >&2
+    echo "Run ./scripts/setup.sh to create one." >&2
+    exit 1
+fi
 
-# Run the server
-python "$DIR/src/server.py"
+export PYTHONPATH="$ROOT/src"
+python "$ROOT/src/server.py"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,9 +26,9 @@ echo "Note: Service accounts require Google Workspace, but OAuth2 works with Gma
 echo ""
 
 # Create virtual environment
-echo "Creating Python virtual environment..."
-python3 -m venv venv
-source venv/bin/activate
+echo "Creating Python virtual environment (.venv)..."
+python3 -m venv .venv
+source .venv/bin/activate
 
 # Install dependencies
 echo "Installing dependencies..."
@@ -99,19 +99,19 @@ echo "MCP Configuration for Claude Desktop"
 echo "==================================="
 echo ""
 echo "Add the following to your Claude Desktop config:"
-echo "(Usually at ~/AppData/Roaming/Claude/claude_desktop_config.json on Windows)"
+echo "(On Windows, edit %APPDATA%\\Claude\\claude_desktop_config.json)"
 echo ""
+REPO_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cat << EOF
 {
   "mcpServers": {
     "google-workspace": {
-      "command": "python",
+      "command": "wsl.exe",
       "args": [
-        "/home/adam/Code/google-workspace-mcp/src/server.py"
-      ],
-      "env": {
-        "PYTHONPATH": "/home/adam/Code/google-workspace-mcp/src"
-      }
+        "-d", "Ubuntu",
+        "bash", "--", "-c",
+        "cd ${REPO_PATH} && source .venv/bin/activate && PYTHONPATH=${REPO_PATH}/src python src/server.py"
+      ]
     }
   }
 }
@@ -119,7 +119,7 @@ EOF
 
 echo ""
 echo "Setup complete! Next steps:"
-echo "1. Activate virtual environment: source venv/bin/activate"
+echo "1. Activate virtual environment: source .venv/bin/activate"
 echo "2. Run the server: python src/server.py"
 echo "3. Configure Claude Desktop with the above settings"
 echo "4. Restart Claude Desktop"


### PR DESCRIPTION
## Summary
- Example configs had hardcoded `/home/adam/...` paths and referenced `venv/` while the actual setup uses `.venv/`. Agents (including the Slack Claude agent) regenerating configs from repo contents alone produced broken paths like `/home/user/google-workspace-mcp` that silently fail to connect.
- Replaces hardcoded paths with a `<ABSOLUTE_PATH_TO_REPO>` placeholder that fails loudly if copied literally.
- Standardizes on `.venv/` (setup.sh now creates it); `run_server.sh` falls back to `venv/` for existing clones.
- Fixes `run_server.sh` — it lived in `scripts/` but resolved `\$DIR/venv` and `\$DIR/src/server.py` as if it were at the repo root.
- Adds a new **MCP Configuration Guidance (for AI agents)** section to `CLAUDE.md` instructing agents to substitute placeholders and verify the venv directory before writing a live config.

## Why this matters
The immediate trigger: Claude Desktop on Windows couldn't connect to this MCP server. The live config had `/home/user/google-workspace-mcp` (no such path) and `source venv/bin/activate` (actual venv is `.venv`). A Slack Claude agent asked to troubleshoot suggested the same broken config because it sourced it from this repo's examples. This change makes the repo self-correcting: next time an agent reads these files, it should produce a working config.

## Test plan
- [ ] Verify `config/*.json` is valid JSON (done locally: `python3 -c 'import json; json.load(...)'`)
- [ ] Verify `scripts/run_server.sh` and `scripts/setup.sh` pass shell syntax check (`bash -n`)
- [ ] Pre-commit hooks green (black, ruff, mypy, bandit, gitleaks) — done on commit
- [ ] CI green
- [ ] Manual: substitute `<ABSOLUTE_PATH_TO_REPO>` in `config/claude_desktop_config.json`, paste into Windows `%APPDATA%\\Claude\\claude_desktop_config.json`, restart Claude Desktop, confirm MCP server connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)