### PR TITLE
fix: drop spurious `--` between `bash` and `-c` in templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ Before producing a config:
 3. For Windows Claude Desktop with WSL, use the `wsl.exe` form from `config/claude_desktop_config.json`. For native Linux/macOS, drop the `wsl.exe` wrapper and call the venv Python directly (see `config/claude_desktop_config_alternative.json`).
 4. After the user updates the config, Claude Desktop must be fully quit and relaunched — MCP servers only load at startup.
 
+### Do not insert `--` between `bash` and `-c`
+
+The correct form is `"bash", "-c", "<command>"`. Do **not** write `"bash", "--", "-c", "<command>"` — the `--` ends bash's option parsing, so bash then treats `-c` as a script filename to open, yielding `bash: -c: No such file or directory` and an immediate MCP disconnect. This mistake appeared in an earlier iteration of the template and broke the live Claude Desktop config on startup.
+
 ## Essential Commands
 
 ### Development Setup

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This MCP server follows the principle of least privilege by intentionally exclud
          "command": "wsl.exe",
          "args": [
            "-d", "Ubuntu",
-           "bash", "--", "-c",
+           "bash", "-c",
            "cd <ABSOLUTE_PATH_TO_REPO> && source .venv/bin/activate && PYTHONPATH=<ABSOLUTE_PATH_TO_REPO>/src python src/server.py"
          ]
        }

--- a/config/claude_desktop_config.json
+++ b/config/claude_desktop_config.json
@@ -5,7 +5,7 @@
       "command": "wsl.exe",
       "args": [
         "-d", "Ubuntu",
-        "bash", "--", "-c",
+        "bash", "-c",
         "cd <ABSOLUTE_PATH_TO_REPO> && source .venv/bin/activate && PYTHONPATH=<ABSOLUTE_PATH_TO_REPO>/src python src/server.py"
       ]
     }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -109,7 +109,7 @@ cat << EOF
       "command": "wsl.exe",
       "args": [
         "-d", "Ubuntu",
-        "bash", "--", "-c",
+        "bash", "-c",
         "cd ${REPO_PATH} && source .venv/bin/activate && PYTHONPATH=${REPO_PATH}/src python src/server.py"
       ]
     }


### PR DESCRIPTION
## Summary
- Follow-up to #75. The live Windows Claude Desktop MCP connection still failed after #75 landed; log showed `bash: -c: No such file or directory`.
- Root cause: `bash -- -c "<command>"` ends bash option parsing at `--`, so `-c` is treated as a script filename. Correct form is `bash -c "<command>"`.
- Verified by running the corrected invocation in WSL: server starts cleanly, scope config loads.
- Adds a CLAUDE.md callout so future agent-generated configs don't reintroduce the same `--` mistake.

## Files
- `config/claude_desktop_config.json`, `scripts/setup.sh`, `README.md`: drop `--`
- `CLAUDE.md`: explicit warning in the AI-agent guidance section

## Test plan
- [ ] JSON template still valid (checked locally)
- [ ] `bash -n scripts/setup.sh` passes (checked locally)
- [ ] Pre-commit hooks green — done on commit
- [ ] CI green
- [ ] Manual: restart Claude Desktop with corrected config, confirm MCP server connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)