### PR TITLE
fix: isolate deploy_token subprocess from MCP JSON-RPC stdout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,9 +11,15 @@ repos:
       - id: ruff
         name: Lint Python code with Ruff
         # No --fix flag: Match CI behavior (fail on issues, no auto-fix)
-      - id: ruff-format
-        name: Format Python code with Ruff
-        args: [--check]  # Match CI: fail if not formatted
+
+  # Code formatting (CI uses black, not ruff format; ruff's 100-char default
+  # disagrees with black's 88-char default, so matching CI avoids churn).
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        name: Format Python code with Black
+        args: [--check]
 
   # Static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -21,8 +27,8 @@ repos:
     hooks:
       - id: mypy
         name: Type check with mypy
-        additional_dependencies: [pydantic>=2.0.0]
-        args: [--config-file=pyproject.toml]  # Match CI: use project config
+        additional_dependencies: [pydantic>=2.0.0, types-aiofiles]
+        args: [--ignore-missing-imports]  # Match CI (build.yml: mypy src --ignore-missing-imports)
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -51,7 +57,7 @@ repos:
     hooks:
       - id: bandit
         name: Security scan with Bandit (high severity)
-        args: [--severity-level, high, -c, pyproject.toml]
+        args: [--severity-level, high]
         additional_dependencies: ["bandit[toml]"]
 
   # Dependency security

--- a/scripts/deploy_token.sh
+++ b/scripts/deploy_token.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
-# Deploy token.pickle to remote hosts after re-authentication
-# Called automatically by google_auth.py after new token is saved
+# Deploy token.pickle to remote hosts after re-authentication.
+# Called automatically by google_auth.py after a new token is saved.
+#
+# NOTE: all diagnostic output is written to stderr. This script is invoked
+# from a process whose stdout is the MCP JSON-RPC channel — writing to
+# stdout corrupts the protocol and causes client-side parse errors.
 
 TOKEN="$HOME/Code/google-workspace-mcp/config/token.pickle"
 
 if [ ! -f "$TOKEN" ]; then
-    echo "Token not found: $TOKEN"
+    echo "Token not found: $TOKEN" >&2
     exit 1
 fi
 
-echo "Deploying token to hostinger..."
-scp "$TOKEN" hostinger:/app/calendar_token.pickle && echo "Done." || echo "Failed to deploy to hostinger."
+echo "Deploying token to hostinger..." >&2
+if scp "$TOKEN" hostinger:/app/calendar_token.pickle >&2; then
+    echo "Done." >&2
+else
+    echo "Failed to deploy to hostinger." >&2
+fi

--- a/src/auth/google_auth.py
+++ b/src/auth/google_auth.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import pickle
+import sys
 import webbrowser
 from pathlib import Path
 from typing import List, Optional
@@ -112,7 +113,14 @@ class GoogleAuthManager:
         )
         if deploy_script.exists():
             logger.info("Deploying token to remote hosts...")
-            await asyncio.create_subprocess_exec(str(deploy_script))
+            # Redirect subprocess stdout/stderr to our stderr. The MCP server's
+            # stdout is the JSON-RPC channel; any inherited stdout from a child
+            # process corrupts the protocol and triggers a client-side parse error.
+            await asyncio.create_subprocess_exec(
+                str(deploy_script),
+                stdout=sys.stderr.fileno(),
+                stderr=sys.stderr.fileno(),
+            )
 
     def _authenticate(self):
         """Perform OAuth2 authentication flow."""


### PR DESCRIPTION
## Summary
Fixes a toast error in Claude Desktop after calendar tool calls. Log showed `Unexpected token 'D', "Deploying "... is not valid JSON` and `Unexpected token 'D', "Done."` immediately after the tool returned results.

### Root cause
`google_auth._save_and_deploy_credentials` launches `scripts/deploy_token.sh` via `asyncio.create_subprocess_exec(str(deploy_script))`. The child inherits the MCP server's stdout, which is the JSON-RPC channel. The script's `echo "Deploying..."` and `echo "Done."` land in the protocol stream, Claude Desktop tries to parse them as JSON, toast fires.

### Two-layer fix
- `src/auth/google_auth.py`: redirect subprocess `stdout`/`stderr` to the parent's stderr fd so any child output goes to MCP logs, not the protocol.
- `scripts/deploy_token.sh`: route all diagnostics to `>&2`. Defensive — safe even if a future caller forgets to redirect.

### Also aligned pre-commit hooks with CI (build.yml)
My PR was the first to touch Python since the pre-commit framework landed in #73, so it surfaced several pre-existing misalignments:
- `mypy` / `bandit` args referenced `pyproject.toml` which has never existed in this repo → removed those args
- `mypy` now installs `types-aiofiles` (CI already does)
- Replaced `ruff-format` hook with `black` — CI only runs `black --check` for formatting, and ruff's 100-char default disagreed with black's 88

## Test plan
- [x] `pytest tests/ -k auth` — 20 passed
- [x] `black --check src/auth/google_auth.py` — clean
- [x] `ruff check src/auth/google_auth.py` — clean
- [x] `bash -n scripts/deploy_token.sh` — clean
- [x] Full pre-commit green on commit
- [ ] CI green
- [ ] Manual: after merge and `git pull` on the local machine, restart Claude Desktop, trigger a calendar tool, confirm no toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)