### PR TITLE
docs: note Claude Code ~/.claude.json venv pitfall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ Before producing a config:
 
 The correct form is `"bash", "-c", "<command>"`. Do **not** write `"bash", "--", "-c", "<command>"` — the `--` ends bash's option parsing, so bash then treats `-c` as a script filename to open, yielding `bash: -c: No such file or directory` and an immediate MCP disconnect. This mistake appeared in an earlier iteration of the template and broke the live Claude Desktop config on startup.
 
+### Claude Code on Linux: same venv pitfall applies to `~/.claude.json`
+
+When this MCP is registered with Claude Code (not Claude Desktop), the config lives in `~/.claude.json` under `projects[<repo-path>].mcpServers["google-workspace"]`. The same `.venv` vs `venv` drift that breaks Claude Desktop configs breaks this one too — `source venv/bin/activate` silently no-ops, the system Python runs without deps, and the server fails to connect. The same entry often appears duplicated under multiple project scopes in `~/.claude.json`; fix all occurrences.
+
 ## Essential Commands
 
 ### Development Setup


### PR DESCRIPTION
## Summary
- Extends the existing "MCP Configuration Guidance (for AI agents)" section in `CLAUDE.md` to cover Claude Code's project-local MCP config (`~/.claude.json`), not just Claude Desktop's `claude_desktop_config.json`.
- Captures today's finding: the same `.venv` vs `venv` drift that bit the Claude Desktop config (fixed yesterday in #75) also bit the Claude Code config on Ubuntu, and the broken entry was duplicated across multiple project scopes — all needed fixing.

## Changes
- `CLAUDE.md`: +4 lines, new subsection under the existing MCP configuration guidance. No code changes.

## Test plan
- [x] `black --check` / `ruff` / `mypy` / `bandit` / `gitleaks` all green via pre-commit
- [x] Reads naturally in context of the surrounding section
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)