### PR TITLE
chore: add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,15 @@ repos:
         args: [--strict]
 
 # Configuration options
+
+  # Secret scanning — block commits containing API keys, tokens, private keys.
+  # Added by add-gitleaks-hook.sh after the 2026-05-10 secret-sprawl audit.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks
+        name: Scan for committed secrets (gitleaks)
+
 default_language_version:
   python: python3.12
 


### PR DESCRIPTION
## Summary
Add `gitleaks` v8.28.0 to the pre-commit hook chain. Blocks commits containing API keys, tokens, and private keys.

## Why
Found during the 2026-05-10 `~/Code/` secret-sprawl audit (full report: `~/Code/.agent-notes/secret-sprawl-audit.md`). Several repos had tracked secrets — this hook catches future leaks at commit time.

## Test plan
- [x] Hook runs on `git commit`
- [ ] `pre-commit install` re-run after merge (one-time, per developer)
- [ ] Verify hook does not flag legitimate files (run `pre-commit run gitleaks --all-files`)

## To disable for a single commit
`SKIP=gitleaks git commit -m "..."` (use sparingly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)