### PR TITLE
chore: add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,15 @@ repos:
         args: [--strict]
 
 # Configuration options
+
+  # Secret scanning — block commits containing API keys, tokens, private keys.
+  # Added by add-gitleaks-hook.sh after the 2026-05-10 secret-sprawl audit.
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks
+        name: Scan for committed secrets (gitleaks)
+
 default_language_version:
   python: python3.12
 


### PR DESCRIPTION
## Summary
- Adds a gitleaks pre-commit hook to block commits containing API keys, tokens, and private keys before they reach git history.
- Part of the workspace-wide rollout following the 2026-05-10 secret-sprawl audit.

## Details
- Hook fires on `git commit`; run manually with `pre-commit run gitleaks --all-files`.
- Single-file change to `.pre-commit-config.yaml` (+9 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)