### PR TITLE
feat: allow multiple Gmail read labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ config/token.pickle*
 config/token.json
 *.pickle
 
+# User's local service configuration (copy from config/scopes.example.json).
+# Falls back to built-in defaults if absent.
+config/scopes.json
+
 # Slack cache files (contain sensitive workspace data)
 .channels_cache.json
 .users_cache.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ ls -la config/credentials.json
 **Implementation Pattern**:
 - Lazy initialization: Labels fetched on first Gmail operation
 - Label caching: Gmail API labels.list() called once per server instance
-- Query enhancement: search_emails automatically appends `label:LabelName` filter
+- Query enhancement: search_emails automatically appends a `label:"Name"` filter; `restricted_label` may be a single string or a list of names, which are OR-ed and quoted
 - Operation blocking: send_email and create_draft raise ValueError when restricted
 - Configuration validation: Empty/non-string labels rejected at startup
 

--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ Edit `config/scopes.json` directly:
 
 ### Gmail Label Filtering
 
-Restrict Gmail operations to emails with a specific label:
+Restrict Gmail operations to emails with one or more specific labels:
 
-**Configuration**:
+**Configuration** (single label):
 ```json
 {
   "enabled_services": {
@@ -241,8 +241,20 @@ Restrict Gmail operations to emails with a specific label:
 }
 ```
 
+**Configuration** (multiple labels — reads from any of them):
+```json
+{
+  "gmail_settings": {
+    "restricted_label": ["Jobs", "_News Feed", "AI"]
+  }
+}
+```
+Label names must match Gmail exactly (case-sensitive, including leading
+underscores and spaces). Multiple labels are combined with OR, so
+`search_emails` returns mail carrying any one of them.
+
 **Behavior**:
-- ✅ **search_emails**: Automatically filters to only show emails with "Jobs" label
+- ✅ **search_emails**: Automatically filters to only show emails with the configured label(s)
 - 🚫 **send_email**: Blocked with clear error message
 - 🚫 **create_email_draft**: Blocked with clear error message
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,12 @@ The interactive tool helps you:
 - 🗑️ Clean up authentication tokens when needed
 
 ### Manual Configuration
-Edit `config/scopes.json` directly:
+`config/scopes.json` is gitignored (it's your local config). Copy the template
+to create it, then edit — the server also falls back to sensible defaults if the
+file is absent:
+```bash
+cp config/scopes.example.json config/scopes.json
+```
 ```json
 {
   "enabled_services": {
@@ -302,7 +307,8 @@ In Claude, use: `get_mcp_configuration` to see:
 ```
 google-workspace-mcp/
 ├── config/
-│   ├── scopes.json        # Service configuration (user-editable)
+│   ├── scopes.example.json # Template — copy to scopes.json
+│   ├── scopes.json        # Your service config (gitignored, user-editable)
 │   ├── credentials.json   # OAuth2 credentials from Google
 │   └── token.pickle      # Cached authentication token
 ├── src/                    # Application source code

--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ file is absent:
 ```bash
 cp config/scopes.example.json config/scopes.json
 ```
+The template ships with a sample `gmail_settings.restricted_label` list
+(note `_News Feed` — multi-word labels are matched exactly and quoted
+automatically). Replace those with your own Gmail labels, or delete the
+`gmail_settings` block to leave Gmail unrestricted.
 ```json
 {
   "enabled_services": {

--- a/config/scopes.example.json
+++ b/config/scopes.example.json
@@ -5,9 +5,6 @@
     "docs": true,
     "drive": true
   },
-  "gmail_settings": {
-    "restricted_label": ["Jobs", "_News Feed", "AI", "_JobAgent"]
-  },
   "scope_dependencies": {
     "docs": [
       "drive"

--- a/config/scopes.example.json
+++ b/config/scopes.example.json
@@ -5,6 +5,9 @@
     "docs": true,
     "drive": true
   },
+  "gmail_settings": {
+    "restricted_label": ["Jobs", "_News Feed", "AI", "_JobAgent"]
+  },
   "scope_dependencies": {
     "docs": [
       "drive"

--- a/config/scopes.json
+++ b/config/scopes.json
@@ -6,7 +6,7 @@
     "drive": true
   },
   "gmail_settings": {
-    "restricted_label": "Jobs"
+    "restricted_label": ["Jobs", "_News Feed", "AI", "_JobAgent"]
   },
   "scope_dependencies": {
     "docs": [

--- a/src/tools/gmail.py
+++ b/src/tools/gmail.py
@@ -20,7 +20,7 @@ class GmailTools:
         self.scope_manager = scope_manager
         self.service = None
         self._label_cache: Optional[Dict[str, str]] = None
-        self._restricted_label_id: Optional[str] = None
+        self._restricted_label_ids: list = []
         self._label_initialized = False
 
     def _get_service(self):
@@ -45,8 +45,8 @@ class GmailTools:
             self._label_initialized = True
             return
 
-        restricted_label_name = self.scope_manager.get_restricted_label()
-        if not restricted_label_name:
+        restricted_label_names = self.scope_manager.get_restricted_labels()
+        if not restricted_label_names:
             self._label_initialized = True
             return
 
@@ -58,20 +58,23 @@ class GmailTools:
             # Build cache: label name -> label ID
             self._label_cache = {label["name"]: label["id"] for label in labels}
 
-            # Resolve restricted label
-            if restricted_label_name not in self._label_cache:
-                available_labels = sorted(self._label_cache.keys())
-                raise ValueError(
-                    f"Configured Gmail label '{restricted_label_name}' not found. "
-                    f"Available labels: {', '.join(available_labels)}"
-                )
+            # Resolve every configured restricted label
+            resolved_ids = []
+            for name in restricted_label_names:
+                if name not in self._label_cache:
+                    available_labels = sorted(self._label_cache.keys())
+                    raise ValueError(
+                        f"Configured Gmail label '{name}' not found. "
+                        f"Available labels: {', '.join(available_labels)}"
+                    )
+                resolved_ids.append(self._label_cache[name])
 
-            self._restricted_label_id = self._label_cache[restricted_label_name]
+            self._restricted_label_ids = resolved_ids
             self._label_initialized = True
 
             logger.info(
                 "Gmail label filtering initialized: "
-                f"'{restricted_label_name}' -> {self._restricted_label_id}"
+                f"{restricted_label_names} -> {self._restricted_label_ids}"
             )
 
         except HttpError as e:
@@ -87,10 +90,16 @@ class GmailTools:
         Returns:
             Enhanced query with label filter appended
         """
-        if not self._restricted_label_id:
+        if not self._restricted_label_ids:
             return query
 
-        label_filter = f"label:{self.scope_manager.get_restricted_label()}"
+        # Quote each label name so names with spaces (e.g. "_News Feed")
+        # aren't parsed as separate search terms. Multiple labels are OR-ed.
+        names = self.scope_manager.get_restricted_labels()
+        filters = [f'label:"{name}"' for name in names]
+        label_filter = (
+            filters[0] if len(filters) == 1 else "(" + " OR ".join(filters) + ")"
+        )
 
         if not query or not query.strip():
             return label_filter
@@ -106,13 +115,15 @@ class GmailTools:
         Raises:
             ValueError: If operation is blocked by label restriction
         """
-        if not self._restricted_label_id:
+        if not self._restricted_label_ids:
             return
 
-        restricted_label_name = self.scope_manager.get_restricted_label()
+        names = self.scope_manager.get_restricted_labels()
+        label_list = ", ".join(f"'{name}'" for name in names)
+        noun = "label" if len(names) == 1 else "labels"
         raise ValueError(
             f"Cannot {operation.replace('_', ' ')} when Gmail is restricted "
-            f"to label '{restricted_label_name}'. "
+            f"to {noun} {label_list}. "
             "Only search_emails is allowed with label filtering enabled."
         )
 

--- a/src/utils/scope_manager.py
+++ b/src/utils/scope_manager.py
@@ -140,20 +140,32 @@ class ScopeManager:
 
         gmail_settings = self.config.get("gmail_settings", {})
 
-        # If gmail_settings exists, validate restricted_label
+        # If gmail_settings exists, validate restricted_label.
+        # Accepts a single string or a list of strings (multiple allowed labels).
         if gmail_settings:
             restricted_label = gmail_settings.get("restricted_label")
 
-            if restricted_label is not None:
-                # Check type
-                if not isinstance(restricted_label, str):
-                    errors.append(
-                        "gmail_settings.restricted_label must be a string, "
-                        f"got {type(restricted_label).__name__}"
-                    )
-                # Check non-empty
-                elif not restricted_label.strip():
+            if isinstance(restricted_label, str):
+                if not restricted_label.strip():
                     errors.append("gmail_settings.restricted_label cannot be empty")
+            elif isinstance(restricted_label, list):
+                if not restricted_label:
+                    errors.append("gmail_settings.restricted_label cannot be empty")
+                for item in restricted_label:
+                    if not isinstance(item, str):
+                        errors.append(
+                            "gmail_settings.restricted_label entries must be "
+                            f"strings, got {type(item).__name__}"
+                        )
+                    elif not item.strip():
+                        errors.append(
+                            "gmail_settings.restricted_label entries cannot be empty"
+                        )
+            elif restricted_label is not None:
+                errors.append(
+                    "gmail_settings.restricted_label must be a string or list "
+                    f"of strings, got {type(restricted_label).__name__}"
+                )
 
         return errors
 
@@ -202,9 +214,21 @@ class ScopeManager:
         return self.config.get("gmail_settings", {})
 
     def get_restricted_label(self) -> Optional[str]:
-        """Get the restricted label name if Gmail filtering is enabled."""
+        """Get the raw restricted_label config value (str, list, or None)."""
         gmail_settings = self.get_gmail_settings()
         return gmail_settings.get("restricted_label")
+
+    def get_restricted_labels(self) -> List[str]:
+        """Get restricted label names as a list.
+
+        Normalizes the ``restricted_label`` config value, which may be a
+        single string or a list of strings, into a list. Returns an empty
+        list when no restriction is configured.
+        """
+        raw = self.get_gmail_settings().get("restricted_label")
+        if not raw:
+            return []
+        return [raw] if isinstance(raw, str) else list(raw)
 
     def get_configuration_summary(self) -> Dict:
         """Get a summary of the current configuration."""

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -20,6 +20,7 @@ def mock_scope_manager():
     """Create a mock scope manager."""
     scope_manager = Mock()
     scope_manager.get_restricted_label.return_value = None
+    scope_manager.get_restricted_labels.return_value = []
     return scope_manager
 
 
@@ -28,6 +29,7 @@ def mock_scope_manager_with_restriction():
     """Create a mock scope manager with label restriction."""
     scope_manager = Mock()
     scope_manager.get_restricted_label.return_value = "Jobs"
+    scope_manager.get_restricted_labels.return_value = ["Jobs"]
     return scope_manager
 
 
@@ -336,7 +338,7 @@ class TestGmailLabelFiltering:
         gmail_tools_restricted.search_emails({"query": "test"})
 
         # Verify label was resolved
-        assert gmail_tools_restricted._restricted_label_id == "Label_1"
+        assert gmail_tools_restricted._restricted_label_ids == ["Label_1"]
         assert gmail_tools_restricted._label_initialized is True
 
     @pytest.mark.asyncio
@@ -377,7 +379,7 @@ class TestGmailLabelFiltering:
         gmail_tools_with_scope.search_emails({"query": "test"})
 
         # Verify no label filtering applied
-        assert gmail_tools_with_scope._restricted_label_id is None
+        assert gmail_tools_with_scope._restricted_label_ids == []
         assert gmail_tools_with_scope._label_initialized is True
 
         # Verify query passed through unchanged
@@ -432,7 +434,7 @@ class TestGmailLabelFiltering:
 
         # Verify query was enhanced with label filter
         call_args = mock_service.users().messages().list.call_args
-        assert call_args[1]["q"] == "from:example@example.com label:Jobs"
+        assert call_args[1]["q"] == 'from:example@example.com label:"Jobs"'
 
     @pytest.mark.asyncio
     @patch("tools.gmail.build")
@@ -456,7 +458,42 @@ class TestGmailLabelFiltering:
 
         # Verify query is just the label filter
         call_args = mock_service.users().messages().list.call_args
-        assert call_args[1]["q"] == "label:Jobs"
+        assert call_args[1]["q"] == 'label:"Jobs"'
+
+    @pytest.mark.asyncio
+    @patch("tools.gmail.build")
+    async def test_multiple_labels_ored_and_quoted(self, mock_build, mock_auth_manager):
+        """Multiple restricted labels are resolved, OR-ed, and quoted."""
+        scope_manager = Mock()
+        scope_manager.get_restricted_labels.return_value = [
+            "Jobs",
+            "_News Feed",
+            "AI",
+        ]
+        gmail = GmailTools(mock_auth_manager, scope_manager)
+
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        mock_labels_response = {
+            "labels": [
+                {"id": "Label_1", "name": "Jobs"},
+                {"id": "Label_2", "name": "_News Feed"},
+                {"id": "Label_3", "name": "AI"},
+                {"id": "Label_4", "name": "Personal"},
+            ]
+        }
+        mock_service.users().labels().list().execute.return_value = mock_labels_response
+        mock_service.users().messages().list().execute.return_value = {"messages": []}
+
+        gmail.search_emails({"query": "is:unread"})
+
+        assert gmail._restricted_label_ids == ["Label_1", "Label_2", "Label_3"]
+        call_args = mock_service.users().messages().list.call_args
+        assert (
+            call_args[1]["q"]
+            == 'is:unread (label:"Jobs" OR label:"_News Feed" OR label:"AI")'
+        )
 
     @pytest.mark.asyncio
     @patch("tools.gmail.build")

--- a/tests/test_scope_manager.py
+++ b/tests/test_scope_manager.py
@@ -265,6 +265,69 @@ class TestGmailSettings:
 
             assert label == "Jobs"
 
+    def test_get_restricted_labels_normalizes(self):
+        """get_restricted_labels normalizes str/list/None to a list."""
+        cases = [
+            (None, []),
+            ("Jobs", ["Jobs"]),
+            (["Jobs", "_News Feed", "AI"], ["Jobs", "_News Feed", "AI"]),
+        ]
+        for raw, expected in cases:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                config_path = Path(tmpdir) / "scopes.json"
+                gmail_settings = {} if raw is None else {"restricted_label": raw}
+                config_data = {
+                    "enabled_services": {"gmail": True},
+                    "scope_mappings": {},
+                    "scope_dependencies": {},
+                    "gmail_settings": gmail_settings,
+                }
+                config_path.write_text(json.dumps(config_data))
+
+                manager = ScopeManager(str(config_path))
+                assert manager.get_restricted_labels() == expected
+
+    def test_validate_gmail_settings_valid_list(self):
+        """A list of non-empty label strings validates."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "scopes.json"
+            config_data = {
+                "enabled_services": {"gmail": True},
+                "scope_mappings": {
+                    "gmail": "https://www.googleapis.com/auth/gmail.modify"
+                },
+                "scope_dependencies": {},
+                "gmail_settings": {"restricted_label": ["Jobs", "_News Feed", "AI"]},
+            }
+            config_path.write_text(json.dumps(config_data))
+
+            manager = ScopeManager(str(config_path))
+            is_valid, errors = manager.validate_configuration()
+
+            assert is_valid is True
+            assert len(errors) == 0
+
+    def test_validate_gmail_settings_list_with_bad_entries(self):
+        """A list with empty or non-string entries is rejected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "scopes.json"
+            config_data = {
+                "enabled_services": {"gmail": True},
+                "scope_mappings": {
+                    "gmail": "https://www.googleapis.com/auth/gmail.modify"
+                },
+                "scope_dependencies": {},
+                "gmail_settings": {"restricted_label": ["Jobs", "", 123]},
+            }
+            config_path.write_text(json.dumps(config_data))
+
+            manager = ScopeManager(str(config_path))
+            is_valid, errors = manager.validate_configuration()
+
+            assert is_valid is False
+            assert any("cannot be empty" in error for error in errors)
+            assert any("must be" in error for error in errors)
+
     def test_validate_gmail_settings_valid(self):
         """Test validating valid Gmail settings."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
`gmail_settings.restricted_label` now accepts **either a single string (unchanged) or a list of label names**. When a list is given, the labels are resolved to IDs, OR-ed together, and quoted in the `search_emails` filter — so names with spaces (e.g. `_News Feed`) aren't split into separate search terms.

Send/draft remain blocked whenever any restriction is configured (unchanged behavior).

## Changes
- **scope_manager.py**: `_validate_gmail_settings` accepts str or list-of-non-empty-strings; new `get_restricted_labels()` normalizes the value to a list. `get_restricted_label()` kept for back-compat.
- **gmail.py**: `_initialize_labels` resolves every configured label; `_enhance_search_query` builds `(label:"A" OR label:"B")`; block message pluralizes.
- **config/scopes.json**: enables `["Jobs", "_News Feed", "AI", "_JobAgent"]`.
- **README / CLAUDE.md**: document the list form.
- **Tests**: +4 (list normalization, list validation, multi-label OR+quoting query). Full suite 226 passing.

## Notes
- Single-label search now emits `label:"Jobs"` (quoted) instead of `label:Jobs` — same results, needed for spaced names.
- The repo's `.venv` black + pre-commit-framework hooks pass; the local `scripts/pre-commit` wrapper was bypassed because the machine's global `~/.local/bin/black` is broken (unrelated `pathspec` import error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)