### PR TITLE
docs: fix README accuracy for fresh clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This MCP server follows the principle of least privilege by intentionally exclud
 
 1. **Clone and setup**:
    ```bash
+   git clone https://github.com/adamkwhite/google-workspace-mcp.git
    cd google-workspace-mcp
    ./scripts/setup.sh
    ```
@@ -260,7 +261,9 @@ Restrict Gmail operations to emails with one or more specific labels:
 ```
 Label names must match Gmail exactly (case-sensitive, including leading
 underscores and spaces). Multiple labels are combined with OR, so
-`search_emails` returns mail carrying any one of them.
+`search_emails` returns mail carrying any one of them. The interactive
+`configure_scopes.py` wizard only sets a single label — for a list, edit
+`config/scopes.json` directly.
 
 **Behavior**:
 - ✅ **search_emails**: Automatically filters to only show emails with the configured label(s)
@@ -340,7 +343,7 @@ google-workspace-mcp/
 - **User-configurable service permissions** - Enable only Calendar, Gmail, Docs, or any combination
 - Minimal scope requests based on enabled services:
   - Calendar: `https://www.googleapis.com/auth/calendar` (if enabled)
-  - Gmail: `https://www.googleapis.com/auth/gmail.send`, `https://www.googleapis.com/auth/gmail.readonly` (if enabled)
+  - Gmail: `https://www.googleapis.com/auth/gmail.modify` (if enabled)
   - Docs: `https://www.googleapis.com/auth/documents`, `https://www.googleapis.com/auth/drive.file` (if enabled)
 - Tokens stored locally, never transmitted
 - Automatic token refresh


### PR DESCRIPTION
Audit of the README from a fresh-clone perspective. Fixes three inaccuracies:

1. **Missing `git clone`** — Quick Start step 1 `cd`'d into a directory that doesn't exist yet.
2. **Wrong Gmail scope** — Security section claimed `gmail.send` + `gmail.readonly`; the server actually requests `gmail.modify` (see `scope_mappings` in `scopes.example.json`).
3. **Wizard label note** — `configure_scopes.py` only sets a single restricted label; documented that lists require editing `scopes.json`.

Verified accurate and left unchanged: tool list vs `server.py`, `setup.sh` behavior, Sheets/Slides "Not Implemented", Calendar/Docs scopes, roadmap.

Separately flagged to the maintainer (not in this PR): `scripts/deploy_token.sh` is tracked and auto-runs on auth, printing hostinger deploy errors for anyone who clones — recommend untracking it like `scopes.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)