### PR TITLE
ci: workflow concurrency and path-filter hygiene

### DIFF
--- a/.github/workflows/close-the-loop.yml
+++ b/.github/workflows/close-the-loop.yml
@@ -17,6 +17,10 @@ on:
     types: [closed]
     branches: [main]
 
+concurrency:
+  group: close-the-loop
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,12 @@ name: "CodeQL"
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/**'
   pull_request:
     branches: ["main"]
   schedule:


### PR DESCRIPTION
## Summary
- Actions-minutes hygiene surfaced by the maintenance sweep: codeql.yml, close-the-loop.yml
- `codeql.yml`: `paths-ignore` on the **push** trigger only. Deliberately NOT on `pull_request` — a skipped workflow never reports a required status check, so a docs-only PR would hang waiting for a check that never runs.
- `close-the-loop.yml`: single global concurrency group with `cancel-in-progress: false`. This workflow commits back to `main`, so a per-ref group would serialize nothing and cancelling would kill an in-flight push. Queueing is the only safe shape.

## Test plan
- [ ] CI green on this PR
